### PR TITLE
Add libretro logger support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,14 @@ Idiomatic Rust API bindings to the libretro API
 [dependencies]
 "libc" = "0.2"
 "libretro-sys" = "0.1"
+"log" = { version = "0.4.8", features = ["std"], optional = true }
 
 [profile.dev]
 panic = "abort"
 
 [profile.release]
 panic = "abort"
+
+[features]
+default = ["logging"]
+logging = ["log"]


### PR DESCRIPTION
This commit adds a default feature called "logging" that adds the rust
log crate as a dependency.

Libraries compiled with libretro-backend can now use the log crate and its
usual log macros to output messages through the libretro interface.